### PR TITLE
Reduce approval policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ typings/
 **/node_modules
 **/packaged.yaml
 **/.aws-sam
+
+tmp/

--- a/slack_approval.yaml
+++ b/slack_approval.yaml
@@ -51,6 +51,16 @@ Resources:
                 Action:
                   - "ssm:GetParametersByPath"
                 Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${AppConfigPath}"
+        -
+          PolicyName: "AllowApprovals"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action:
+                  - "codepipeline:PutApprovalResult"
+                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
 
   ApprovalLambda:
     Type: AWS::Serverless::Function

--- a/slack_pipeline_attachment.yaml
+++ b/slack_pipeline_attachment.yaml
@@ -70,31 +70,6 @@ Conditions:
     - ''
 
 Resources:
-  AllowApprovalPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: !Sub "${AWS::StackName}-AllowApprovals"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          -
-            Effect: "Allow"
-            Action:
-              - "codepipeline:PutApprovalResult"
-            Resource: !Sub
-              - "arn:aws:codepipeline:${ResolvedPipelineRegion}:${AWS::AccountId}:${ResolvedPipelineName}/*"
-              -
-                ResolvedPipelineName: !If
-                  - NoPipelineExportName
-                  - !Ref PipelineName
-                  - Fn::ImportValue: !Ref PipelineExportName
-                ResolvedPipelineRegion: !If
-                  - NoPipelineRegion
-                  - !Ref AWS::Region
-                  - !Ref PipelineRegion
-      Roles:
-        - Fn::ImportValue: !Sub '${ApprovalStackName}:LambdaExecutionRole'
-
   NotifyLambdaSNSSubscription:
     Type: "AWS::SNS::Subscription"
     Properties:


### PR DESCRIPTION
Previous implementation attached additional policies to the approval lambda to allow the lambda to approve specific pipelines. While this would be more secure, we're going to eventually hit the IAM limits on attached policies. Changing this to just allow approving all pipelines in a region for the account.